### PR TITLE
add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+cache:
+  directories:
+    - ~/.npm
+notifications:
+  email: false
+node_js:
+  - '8'
+after_success:
+  - npm run travis-deploy-once "npm run semantic-release"
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const assert = require('assert')
 const isURL = require('is-url')
 const isDev = require('electron-is-dev')
 const ms = require('ms')
-const {app, autoUpdater, dialog} = require('electron')
 
 module.exports = function updater (opts = {}) {
   // check for bad input early, so it will be logged during development
@@ -16,13 +15,14 @@ module.exports = function updater (opts = {}) {
     return
   }
 
-  app.isReady()
+  opts.electron.app.isReady()
     ? initUpdater(opts)
-    : app.on('ready', () => initUpdater(opts))
+    : opts.electron.app.on('ready', () => initUpdater(opts))
 }
 
 function initUpdater (opts) {
-  const {host, repo, updateInterval, debug} = opts
+  const {host, repo, updateInterval, debug, electron} = opts
+  const {app, autoUpdater, dialog} = electron
   const feedURL = `${host}/${repo}/${process.platform}/${app.getVersion()}`
 
   function log () {
@@ -76,6 +76,9 @@ function validateInput (opts) {
   }
   const {host, repo, updateInterval, debug} = Object.assign({}, defaults, opts)
 
+  // allows electron to be mocked in tests
+  const electron = opts.electron || require('electron')
+
   assert(
     repo && repo.length && repo.includes('/'),
     'repo is required and should be in the format `owner/repo`'
@@ -101,5 +104,5 @@ function validateInput (opts) {
     'debug must be a boolean'
   )
 
-  return {host, repo, updateInterval, debug}
+  return {host, repo, updateInterval, debug, electron}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-electron-app",
-  "version": "1.0.1",
+  "version": "0.0.0-development",
   "description": "A drop-in module that adds autoUpdating capabilities to Electron apps",
   "repository": "https://github.com/electron/update-electron-app",
   "main": "index.js",
@@ -13,11 +13,15 @@
   "devDependencies": {
     "jest": "^22.4.3",
     "standard": "^11.0.1",
-    "standard-markdown": "^4.0.2"
+    "standard-markdown": "^4.0.2",
+    "travis-deploy-once": "^4.4.1",
+    "semantic-release": "^15.1.7"
   },
   "scripts": {
     "test": "jest && standard --fix && standard-markdown",
-    "watch": "jest --watch --notify --notifyMode=change --coverage"
+    "watch": "jest --watch --notify --notifyMode=change --coverage",
+    "travis-deploy-once": "travis-deploy-once",
+    "semantic-release": "semantic-release"
   },
   "standard": {
     "env": {

--- a/test.js
+++ b/test.js
@@ -1,16 +1,61 @@
-// const proxyquire = require('proxyquire')
-// const mock = require('mock-require')
+const updater = require('.')
+const repo = 'some-owner/some-repo'
+const electron = {
+  app: {
+    getVersion: () => { return '1.2.3' },
+    isReady: () => { return true },
+    on: (eventName) => { /* no-op */ }
+  },
+  autoUpdater: {
+    checkForUpdates: () =>  { /* no-op */ },
+    on: (eventName) => { /* no-op */ },
+    setFeedURL: () =>  { /* no-op */ }
+  },
+  dialog: {
+    showMessageBox: () =>  { /* no-op */ }
+  }
+}
 
-// const updater = mock('./index.js', {
-//   'electron': {
-//     app: {},
-//     autoUpdater: {},
-//     dialog: {}
-//   }
-// })
-
-// TODO: Figure out how to mock require('electron')
-
-xtest('exports a function', () => {
+test('exports a function', () => {
   expect(typeof updater).toBe('function')
 })
+
+describe('repository', () => {
+  test('is required', () => {
+    expect(() => {
+      updater({electron})
+    }).toThrowError('repo is required and should be in the format `owner/repo`')
+  })
+})
+
+describe('host', () => {
+  test('must a valid HTTPS URL', () => {
+    expect(() => {
+      updater({repo, electron, host: 'http://example.com'})
+    }).toThrowError('host must be a valid HTTPS URL')
+  })
+})
+
+describe('debug', () => {
+  test('must be a boolean', () => {
+    expect(() => {
+      updater({repo, electron, debug: 'yep'})
+    }).toThrowError('debug must be a boolean')
+  })
+})
+
+describe('updateInterval', () => {
+  test('must be 30 seconds or more', () => {
+    expect(() => {
+      updater({repo, electron, updateInterval: '20 seconds'})
+    }).toThrowError('updateInterval must be `30 seconds` or more')
+  })
+  
+  test('must be a string', () => {
+    expect(() => {
+      updater({repo, electron, updateInterval: 3000})
+    }).toThrowError('updateInterval must be a human-friendly string interval like `90 seconds`')
+  })
+})
+
+


### PR DESCRIPTION
Resolves #12 

I was unsuccessful in my attempts to mock `require('electron')` with [proxyquire](https://ghub.io/proxyquire) and [mock-require](https://ghub.io/mock-require), so I worked around that by adding `electron` as an option when calling the function. This allows tests to pass in a fake electron object with methods mocked out, while the default use case will just fall back to `require('electron')`