### PR TITLE
Change defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,6 @@ function initUpdater (opts) {
   log('feedURL', feedURL)
   autoUpdater.setFeedURL(feedURL)
 
-  setInterval(() => { autoUpdater.checkForUpdates() }, updateInterval)
-
   autoUpdater.on('error', err => {
     log('updater error')
     log(err)
@@ -69,12 +67,16 @@ function initUpdater (opts) {
       if (response === 0) autoUpdater.quitAndInstall()
     })
   })
+
+  // check for updates right away and keep checking later
+  autoUpdater.checkForUpdates()
+  setInterval(() => { autoUpdater.checkForUpdates() }, updateInterval)
 }
 
 function validateInput (opts) {
   const defaults = {
     host: 'https://update.electronjs.org',
-    updateInterval: '60 seconds',
+    updateInterval: '10 minutes',
     debug: true
   }
   const {host, updateInterval, debug} = Object.assign({}, defaults, opts)
@@ -107,12 +109,12 @@ function validateInput (opts) {
 
   assert(
     typeof updateInterval === 'string' && updateInterval.match(/^\d+/),
-    'updateInterval must be a human-friendly string interval like `90 seconds`'
+    'updateInterval must be a human-friendly string interval like `20 minutes`'
   )
 
   assert(
-    ms(updateInterval) >= 30 * 1000,
-    'updateInterval must be `30 seconds` or more'
+    ms(updateInterval) >= 5 * 60 * 1000,
+    'updateInterval must be `5 minutes` or more'
   )
 
   assert(

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,15 @@ Powered by the free and open-source [update.electronjs.org](https://update.elect
 
 ![screenshot](screenshot.png)
 
+## Requirements
+
+Before using this module, make sure your Electron app meets these criteria:
+
+- Your app runs on macOS or Windows
+- Your app has a public GitHub repository
+- Your builds are published to GitHub Releases
+- Your builds are code-signed
+
 ## Installation
 
 ```sh

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 > A drop-in module that adds autoUpdating capabilities to Electron apps
 
+Powered by the free and open-source [update.electronjs.org](https://update.electronjs.org) service.
+
 ![screenshot](screenshot.png)
 
 ## Installation
@@ -18,7 +20,13 @@ Drop this anywhere in your main process:
 require('update-electron-app')()
 ```
 
-The module will automatically wait for your app's `ready` event to fire.
+That's it! Here's what happens by default:
+
+- Repository URL is found in your app's `package.json` file.
+- Your app will check for updates at startup, then every ten minutes. This interval is [configurable](#API).
+- No need to wait for your app's `ready` event; the module figures that out.
+- If an update is found, it will automatically be downloaded in the background.
+- When an update is finished downloading, a dialog is displayed allowing the user to restart the app now or later.
 
 ## API
 
@@ -28,16 +36,15 @@ Options:
 
 - `repo` String (optional) - A GitHub repository in the format `owner/repo`. Defaults to your `package.json`'s `"repository"` field
 - `host` String (optional) - Defaults to `https://update.electronjs.org`
-- `updateInterval` String (optional) - How frequently to check for updates. Defaults to `1 minute`
+- `updateInterval` String (optional) - How frequently to check for updates. Defaults to `10 minutes`. Minimum allowed interval is `5 minutes`.
 - `debug` Boolean (optional) - Display debug output. Defaults to `true`
-
-## Tests
-
-```sh
-npm install
-npm test
-```
 
 ## License
 
 MIT
+
+## See Also
+
+If your app is packaged with `electron-builder`, you may not need this module. 
+Builder has its own built-in mechanism for updating apps. Find out more at 
+[electron.build/auto-update](https://www.electron.build/auto-update.).

--- a/test.js
+++ b/test.js
@@ -67,15 +67,15 @@ describe('debug', () => {
 })
 
 describe('updateInterval', () => {
-  test('must be 30 seconds or more', () => {
+  test('must be 5 minutes or more', () => {
     expect(() => {
       updater({repo, electron, updateInterval: '20 seconds'})
-    }).toThrowError('updateInterval must be `30 seconds` or more')
+    }).toThrowError('updateInterval must be `5 minutes` or more')
   })
 
   test('must be a string', () => {
     expect(() => {
       updater({repo, electron, updateInterval: 3000})
-    }).toThrowError('updateInterval must be a human-friendly string interval like `90 seconds`')
+    }).toThrowError('updateInterval must be a human-friendly string interval like `20 minutes`')
   })
 })


### PR DESCRIPTION
- Call `autoUpdater.checkForUpdates()` right away
- Default to `10 minutes` for polling
- Disallow polling more frequent than `5 minutes`
- Update README with new defaults, and explain what the module does