### PR TITLE
feat: add User-Agent request header

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,17 @@ const ms = require('ms')
 const gh = require('github-url-to-object')
 const path = require('path')
 const fs = require('fs')
+const os = require('os')
+const {format} = require('util')
+const pkg = require('./package.json')
+const userAgent = format(
+  '%s/%s (%s: %s %s)',
+  pkg.name,
+  pkg.version,
+  os.platform(),
+  os.type(),
+  os.arch()
+)
 
 module.exports = function updater (opts = {}) {
   // check for bad input early, so it will be logged during development
@@ -27,13 +38,15 @@ function initUpdater (opts) {
   const {host, repo, updateInterval, debug, electron} = opts
   const {app, autoUpdater, dialog} = electron
   const feedURL = `${host}/${repo}/${process.platform}/${app.getVersion()}`
+  const requestHeaders = {'User-Agent': userAgent}
 
   function log () {
     if (debug) console.log.apply(console, arguments)
   }
 
   log('feedURL', feedURL)
-  autoUpdater.setFeedURL(feedURL)
+  log('requestHeaders', requestHeaders)
+  autoUpdater.setFeedURL(feedURL, requestHeaders)
 
   setInterval(() => { autoUpdater.checkForUpdates() }, updateInterval)
 

--- a/index.js
+++ b/index.js
@@ -9,11 +9,10 @@ const os = require('os')
 const {format} = require('util')
 const pkg = require('./package.json')
 const userAgent = format(
-  '%s/%s (%s: %s %s)',
+  '%s/%s (%s: %s)',
   pkg.name,
   pkg.version,
   os.platform(),
-  os.type(),
   os.arch()
 )
 


### PR DESCRIPTION
This is a way to resolve #14 that doesn't include user-specific data.

Trying to adhere to [official User-Agent syntax](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent):

```
User-Agent: <product> / <product-version> <comment>

Common format for web browsers:

User-Agent: Mozilla/<version> (<system-information>) <platform> (<platform-details>) <extensions>
```

The string should look something like

```
update-electron-app/1.1.0 (darwin: x64)
```

