### PR TITLE
fix: typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,4 +56,4 @@ MIT
 
 If your app is packaged with `electron-builder`, you may not need this module. 
 Builder has its own built-in mechanism for updating apps. Find out more at 
-[electron.build/auto-update](https://www.electron.build/auto-update.).
+[electron.build/auto-update](https://www.electron.build/auto-update).


### PR DESCRIPTION
The PRs landed in the last seven days haven't triggered releases. The PR titles were semantic, but the commit messages were not, and I was using the default merge strategy which doesn't not create a semantic merge commit based on the PR title. Cool story, I know.

I've updated this repo to only allow squash commits, and I've installed the [semantic-pull-requests](https://github.com/apps/semantic-pull-requests) probot. This should enable us to trigger new semantic releases with semantic PR titles. 🤞 