### PR TITLE
fix: convert interval to ms

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function initUpdater (opts) {
 
   // check for updates right away and keep checking later
   autoUpdater.checkForUpdates()
-  setInterval(() => { autoUpdater.checkForUpdates() }, updateInterval)
+  setInterval(() => { autoUpdater.checkForUpdates() }, ms(updateInterval))
 }
 
 function validateInput (opts) {


### PR DESCRIPTION
@juliangruber I forgot to call `ms` on the `updateInterval` option when using `setInterval`, so it was evaluating to zero and the service was getting hammered 🔨  Oops!

This should fix it.