### PR TITLE
feat: add notifyUser option to disable the upgrade dialog prompt

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,21 +70,23 @@ function initUpdater (opts) {
     log('update-not-available')
   })
 
-  autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName, releaseDate, updateURL) => {
-    log('update-downloaded', arguments)
+  if (opts.nagUser) {
+    autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName, releaseDate, updateURL) => {
+      log('update-downloaded', arguments)
 
-    const dialogOpts = {
-      type: 'info',
-      buttons: ['Restart', 'Later'],
-      title: 'Application Update',
-      message: process.platform === 'win32' ? releaseNotes : releaseName,
-      detail: 'A new version has been downloaded. Restart the application to apply the updates.'
-    }
+      const dialogOpts = {
+        type: 'info',
+        buttons: ['Restart', 'Later'],
+        title: 'Application Update',
+        message: process.platform === 'win32' ? releaseNotes : releaseName,
+        detail: 'A new version has been downloaded. Restart the application to apply the updates.'
+      }
 
-    dialog.showMessageBox(dialogOpts, (response) => {
-      if (response === 0) autoUpdater.quitAndInstall()
+      dialog.showMessageBox(dialogOpts, (response) => {
+        if (response === 0) autoUpdater.quitAndInstall()
+      })
     })
-  })
+  }
 
   // check for updates right away and keep checking later
   autoUpdater.checkForUpdates()
@@ -95,9 +97,10 @@ function validateInput (opts) {
   const defaults = {
     host: 'https://update.electronjs.org',
     updateInterval: '10 minutes',
-    logger: console
+    logger: console,
+    nagUser: true
   }
-  const {host, updateInterval, logger} = Object.assign({}, defaults, opts)
+  const {host, updateInterval, logger, nagUser} = Object.assign({}, defaults, opts)
 
   // allows electron to be mocked in tests
   const electron = opts.electron || require('electron')
@@ -140,5 +143,5 @@ function validateInput (opts) {
     'function'
   )
 
-  return {host, repo, updateInterval, logger, electron}
+  return {host, repo, updateInterval, logger, electron, nagUser}
 }

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function initUpdater (opts) {
     log('update-not-available')
   })
 
-  if (opts.nagUser) {
+  if (opts.notifyUser) {
     autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName, releaseDate, updateURL) => {
       log('update-downloaded', arguments)
 
@@ -98,9 +98,9 @@ function validateInput (opts) {
     host: 'https://update.electronjs.org',
     updateInterval: '10 minutes',
     logger: console,
-    nagUser: true
+    notifyUser: true
   }
-  const {host, updateInterval, logger, nagUser} = Object.assign({}, defaults, opts)
+  const {host, updateInterval, logger, notifyUser} = Object.assign({}, defaults, opts)
 
   // allows electron to be mocked in tests
   const electron = opts.electron || require('electron')
@@ -143,5 +143,5 @@ function validateInput (opts) {
     'function'
   )
 
-  return {host, repo, updateInterval, logger, electron, nagUser}
+  return {host, repo, updateInterval, logger, electron, notifyUser}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# update-electron-app 
+# update-electron-app
 
 > A drop-in module that adds autoUpdating capabilities to Electron apps
 
@@ -57,20 +57,22 @@ Options:
 - `host` String (optional) - Defaults to `https://update.electronjs.org`
 - `updateInterval` String (optional) - How frequently to check for updates. Defaults to `10 minutes`. Minimum allowed interval is `5 minutes`.
 - `logger` Object (optional) - A custom logger object that defines a `log` function. Defaults to `console`. See [electron-log](https://github.com/megahertz/electron-log), a module that aggregates logs from main and renderer processes into a single file.
+- `nagUser` Boolean (optional) - Defaults to true.  When enabled the user will be
+  prompted to apply the update immediately after download.
 
 ## FAQ
 
 #### What kinds of assets do I need to build?
 
-For macOS, you'll need to build a `.zip` file and include it in your GitHub Release. 
+For macOS, you'll need to build a `.zip` file and include it in your GitHub Release.
 Use [electron-forge] or [electron-installer-zip] to package your app as a zip.
 
-For Windows, you'll need to build a `.exe` file and include it in your GitHub Release. 
+For Windows, you'll need to build a `.exe` file and include it in your GitHub Release.
 
 #### Why is my app launching multiple times?
 
 Windows apps have an update process that requires multiple application restarts.
-You can use the [electron-squirrel-startup](https://github.com/mongodb-js/electron-squirrel-startup) module to improve this 
+You can use the [electron-squirrel-startup](https://github.com/mongodb-js/electron-squirrel-startup) module to improve this
 behavior.
 
 #### Can I use this module by uploading my private app's builds to a public GitHub repository?
@@ -83,8 +85,8 @@ MIT
 
 ## See Also
 
-If your app is packaged with `electron-builder`, you may not need this module. 
-Builder has its own built-in mechanism for updating apps. Find out more at 
+If your app is packaged with `electron-builder`, you may not need this module.
+Builder has its own built-in mechanism for updating apps. Find out more at
 [electron.build/auto-update](https://www.electron.build/auto-update).
 
 [electron-forge]: https://github.com/electron-userland/electron-forge

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Options:
 - `host` String (optional) - Defaults to `https://update.electronjs.org`
 - `updateInterval` String (optional) - How frequently to check for updates. Defaults to `10 minutes`. Minimum allowed interval is `5 minutes`.
 - `logger` Object (optional) - A custom logger object that defines a `log` function. Defaults to `console`. See [electron-log](https://github.com/megahertz/electron-log), a module that aggregates logs from main and renderer processes into a single file.
-- `notifyUser` Boolean (optional) - Defaults to true.  When enabled the user will be
+- `notifyUser` Boolean (optional) - Defaults to `true`.  When enabled the user will be
   prompted to apply the update immediately after download.
 
 ## FAQ

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Options:
 - `host` String (optional) - Defaults to `https://update.electronjs.org`
 - `updateInterval` String (optional) - How frequently to check for updates. Defaults to `10 minutes`. Minimum allowed interval is `5 minutes`.
 - `logger` Object (optional) - A custom logger object that defines a `log` function. Defaults to `console`. See [electron-log](https://github.com/megahertz/electron-log), a module that aggregates logs from main and renderer processes into a single file.
-- `nagUser` Boolean (optional) - Defaults to true.  When enabled the user will be
+- `notifyUser` Boolean (optional) - Defaults to true.  When enabled the user will be
   prompted to apply the update immediately after download.
 
 ## FAQ


### PR DESCRIPTION
Related to #22, I want a way to disable the hard coded user prompt when a new update is downloaded.  