### PR TITLE
refactor: update `dialog.showMessageBox` to use promise version

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function initUpdater (opts) {
         detail: 'A new version has been downloaded. Restart the application to apply the updates.'
       }
 
-      dialog.showMessageBox(dialogOpts, (response) => {
+      dialog.showMessageBox(dialogOpts).then(({ response }) => {
         if (response === 0) autoUpdater.quitAndInstall()
       })
     })

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "is-url": "^1.2.4",
     "ms": "^2.1.1"
   },
+  "peerDependencies": {
+    "electron": ">= 6.0.0"
+  },
   "devDependencies": {
     "@continuous-auth/semantic-release-npm": "^2.0.0",
     "jest": "^22.4.3",


### PR DESCRIPTION
BREAKING CHANGE: Minimum supported Electron version is 6.x.y.

This PR updates the `dialog.showMessageBox` to use the async version instead of the old callback version.

Fixes #57 