### PR TITLE
fix: replace arguments object with array of params

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function initUpdater (opts) {
 
   if (opts.notifyUser) {
     autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName, releaseDate, updateURL) => {
-      log('update-downloaded', arguments)
+      log('update-downloaded', [event, releaseNotes, releaseName, releaseDate, updateURL])
 
       const dialogOpts = {
         type: 'info',


### PR DESCRIPTION
When logging on update-downloaded the arguments object is not available inside an arrow function, replaced it with the array of  params