### PR TITLE
fix(types): accurate logger definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,6 @@
 declare namespace updateElectronApp {
   export interface ILogger {
     log(message: string): void;
-    info(message: string): void;
-    error(message: string): void;
-    warn(message: string): void;
   }
 
   export interface IUpdateElectronAppOptions<L = ILogger> {


### PR DESCRIPTION
Upon investigation of the `index.js` I have noticed that you are not using any level-specific logging functions like `warn()`, `error()` etc. in the code but only `log()` so this PR drops the requirement to have these functions for the logging purpuse.