### PR TITLE
feat: export a utility class instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ npm i update-electron-app
 Drop this anywhere in your main process:
 
 ```js
-const { updateElectronApp } = require('update-electron-app')
-updateElectronApp()
+const { updateElectron } = require('update-electron-app')
+updateElectron.setup()
 ```
 
 By default your repository URL is found in [your app's `package.json` file](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository).
@@ -45,8 +45,8 @@ By default your repository URL is found in [your app's `package.json` file](http
 You can also specify custom options:
 
 ```js
-const { updateElectronApp, UpdateSourceType } = require('update-electron-app')
-updateElectronApp({
+const { updateElectron, UpdateSourceType } = require('update-electron-app')
+updateElectron.setup({
   updateSource: {
     type: UpdateSourceType.ElectronPublicUpdateService,
     repo: 'github-user/repo'
@@ -59,8 +59,8 @@ updateElectronApp({
 ### With static file storage
 
 ```js
-const { updateElectronApp, UpdateSourceType } = require('update-electron-app')
-updateElectronApp({
+const { updateElectron, UpdateSourceType } = require('update-electron-app')
+updateElectron.setup({
   updateSource: {
     type: UpdateSourceType.StaticStorage,
     baseUrl: `https://my-bucket.s3.amazonaws.com/my-app-updates/${process.platform}/${process.arch}`
@@ -70,7 +70,7 @@ updateElectronApp({
 
 ## What happens?
 
-Once you've called `updateElectronApp` as documented above, that's it! Here's what happens by default:
+Once you've called `updateElectron.setup()` as documented above, that's it! Here's what happens by default:
 
 - Your app will check for updates at startup, then every ten minutes. This interval is [configurable](#API).
 - No need to wait for your app's `ready` event; the module figures that out.

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ class updateElectronClass {
     else app.on('ready', () => this.initUpdater(safeOpts));
   }
 
-  initUpdater(opts: ReturnType<typeof this.validateInput>) {
+  private initUpdater(opts: ReturnType<typeof this.validateInput>) {
     const { updateSource, updateInterval, logger, electron } = opts;
 
     // exit early on unsupported platforms, e.g. `linux`
@@ -220,7 +220,7 @@ class updateElectronClass {
     this.isActive = false;
   }
 
-  guessRepo(electron: typeof Electron.Main) {
+  private guessRepo(electron: typeof Electron.Main) {
     const pkgBuf = fs.readFileSync(path.join(electron.app.getAppPath(), 'package.json'));
     const pkg = JSON.parse(pkgBuf.toString());
     const repoString = pkg.repository?.url || pkg.repository;
@@ -229,7 +229,7 @@ class updateElectronClass {
     return `${repoObject.user}/${repoObject.repo}`;
   }
 
-  validateInput(opts: IUpdateElectronAppOptions) {
+  private validateInput(opts: IUpdateElectronAppOptions) {
     const defaults = {
       host: 'https://update.electronjs.org',
       updateInterval: '10 minutes',

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,174 +80,215 @@ const pkg = require('../package.json');
 const userAgent = format('%s/%s (%s: %s)', pkg.name, pkg.version, os.platform(), os.arch());
 const supportedPlatforms = ['darwin', 'win32'];
 
-export function updateElectronApp(opts: IUpdateElectronAppOptions = {}) {
-  // check for bad input early, so it will be logged during development
-  const safeOpts = validateInput(opts);
+class updateElectronClass {
+  isActive: boolean = false;
+  isChecking: boolean = false;
+  isError: boolean = false;
+  isDownloading: boolean = false;
+  isDownloaded: boolean = false;
+  updateTimer?: NodeJS.Timer;
 
-  // don't attempt to update during development
-  if (!app.isPackaged) {
-    const message =
-      'update-electron-app config looks good; aborting updates since app is in development mode';
-    opts.logger ? opts.logger.log(message) : console.log(message);
-    return;
-  }
+  dialogTitle: string = 'Application Update';
+  dialogDetail: string =
+    'A new version has been downloaded. Restart the application to apply the updates.';
+  dialogButtonRestart: string = 'Restart';
+  dialogButtonLater: string = 'Later';
 
-  if (safeOpts.electron.app.isReady()) initUpdater(safeOpts);
-  else app.on('ready', () => initUpdater(safeOpts));
-}
+  setup(opts: IUpdateElectronAppOptions = {}) {
+    // check for bad input early, so it will be logged during development
+    const safeOpts = this.validateInput(opts);
 
-function initUpdater(opts: ReturnType<typeof validateInput>) {
-  const { updateSource, updateInterval, logger, electron } = opts;
-
-  // exit early on unsupported platforms, e.g. `linux`
-  if (!supportedPlatforms.includes(process?.platform)) {
-    log(`Electron's autoUpdater does not support the '${process.platform}' platform. Ref: https://www.electronjs.org/docs/latest/api/auto-updater#platform-notices`);
-    return;
-  }
-
-  const { app, autoUpdater, dialog } = electron;
-  let feedURL: string;
-  let serverType: 'default' | 'json' = 'default';
-  switch (updateSource.type) {
-    case UpdateSourceType.ElectronPublicUpdateService: {
-      feedURL = `${updateSource.host}/${updateSource.repo}/${process.platform}-${
-        process.arch
-      }/${app.getVersion()}`;
-      break;
+    // don't attempt to update during development
+    if (!app.isPackaged) {
+      const message =
+        'update-electron-app config looks good; aborting updates since app is in development mode';
+      opts.logger ? opts.logger.log(message) : console.log(message);
+      return;
     }
-    case UpdateSourceType.StaticStorage: {
-      feedURL = updateSource.baseUrl;
-      if (process.platform === 'darwin') {
-        feedURL += '/RELEASES.json';
-        serverType = 'json';
+
+    if (safeOpts.electron.app.isReady()) this.initUpdater(safeOpts);
+    else app.on('ready', () => this.initUpdater(safeOpts));
+  }
+
+  initUpdater(opts: ReturnType<typeof this.validateInput>) {
+    const { updateSource, updateInterval, logger, electron } = opts;
+
+    // exit early on unsupported platforms, e.g. `linux`
+    if (!supportedPlatforms.includes(process?.platform)) {
+      log(
+        `Electron's autoUpdater does not support the '${process.platform}' platform. Ref: https://www.electronjs.org/docs/latest/api/auto-updater#platform-notices`,
+      );
+      return;
+    }
+
+    const { app, autoUpdater, dialog } = electron;
+    let feedURL: string;
+    let serverType: 'default' | 'json' = 'default';
+    switch (updateSource.type) {
+      case UpdateSourceType.ElectronPublicUpdateService: {
+        feedURL = `${updateSource.host}/${updateSource.repo}/${process.platform}-${
+          process.arch
+        }/${app.getVersion()}`;
+        break;
       }
-      break;
+      case UpdateSourceType.StaticStorage: {
+        feedURL = updateSource.baseUrl;
+        if (process.platform === 'darwin') {
+          feedURL += '/RELEASES.json';
+          serverType = 'json';
+        }
+        break;
+      }
     }
-  }
 
-  const requestHeaders = { 'User-Agent': userAgent };
+    const requestHeaders = { 'User-Agent': userAgent };
 
-  function log(...args: any[]) {
-    logger.log(...args);
-  }
+    function log(...args: any[]) {
+      logger.log(...args);
+    }
 
-  log('feedURL', feedURL);
-  log('requestHeaders', requestHeaders);
-  autoUpdater.setFeedURL({
-    url: feedURL,
-    headers: requestHeaders,
-    serverType,
-  });
+    log('feedURL', feedURL);
+    log('requestHeaders', requestHeaders);
+    autoUpdater.setFeedURL({
+      url: feedURL,
+      headers: requestHeaders,
+      serverType,
+    });
 
-  autoUpdater.on('error', (err) => {
-    log('updater error');
-    log(err);
-  });
+    autoUpdater.on('error', (err) => {
+      log('updater error');
+      log(err);
+      this.isChecking = false;
+      this.isError = true;
+    });
 
-  autoUpdater.on('checking-for-update', () => {
-    log('checking-for-update');
-  });
+    autoUpdater.on('checking-for-update', () => {
+      log('checking-for-update');
+      this.isChecking = true;
+      this.isError = false;
+    });
 
-  autoUpdater.on('update-available', () => {
-    log('update-available; downloading...');
-  });
+    autoUpdater.on('update-available', () => {
+      log('update-available; downloading...');
+      this.isChecking = false;
+      this.isDownloading = true;
+    });
 
-  autoUpdater.on('update-not-available', () => {
-    log('update-not-available');
-  });
+    autoUpdater.on('update-not-available', () => {
+      log('update-not-available');
+      this.isChecking = false;
+    });
 
-  if (opts.notifyUser) {
-    autoUpdater.on(
-      'update-downloaded',
-      (event, releaseNotes, releaseName, releaseDate, updateURL) => {
-        log('update-downloaded', [event, releaseNotes, releaseName, releaseDate, updateURL]);
+    if (opts.notifyUser) {
+      autoUpdater.on(
+        'update-downloaded',
+        (event, releaseNotes, releaseName, releaseDate, updateURL) => {
+          log('update-downloaded', [event, releaseNotes, releaseName, releaseDate, updateURL]);
+          this.isDownloading = false;
+          this.isDownloaded = true;
 
-        const dialogOpts = {
-          type: 'info',
-          buttons: ['Restart', 'Later'],
-          title: 'Application Update',
-          message: process.platform === 'win32' ? releaseNotes : releaseName,
-          detail:
-            'A new version has been downloaded. Restart the application to apply the updates.',
-        };
+          const dialogOpts = {
+            type: 'info',
+            buttons: [this.dialogButtonRestart, this.dialogButtonLater],
+            title: this.dialogTitle,
+            message: process.platform === 'win32' ? releaseNotes : releaseName,
+            detail: this.dialogDetail,
+          };
 
-        dialog.showMessageBox(dialogOpts).then(({ response }) => {
-          if (response === 0) autoUpdater.quitAndInstall();
-        });
-      },
-    );
-  }
+          dialog.showMessageBox(dialogOpts).then(({ response }) => {
+            if (response === 0) autoUpdater.quitAndInstall();
+          });
+        },
+      );
+    }
 
-  // check for updates right away and keep checking later
-  autoUpdater.checkForUpdates();
-  setInterval(() => {
+    this.isActive = true;
+    // Clear up any previous timer we have initiated in case of a reconfiguration
+    if (this.updateTimer) {
+      clearInterval(this.updateTimer);
+    }
+
+    // check for updates right away and keep checking later
     autoUpdater.checkForUpdates();
-  }, ms(updateInterval));
-}
+    this.updateTimer = setInterval(() => {
+      autoUpdater.checkForUpdates();
+    }, ms(updateInterval));
+  }
 
-function guessRepo(electron: typeof Electron.Main) {
-  const pkgBuf = fs.readFileSync(path.join(electron.app.getAppPath(), 'package.json'));
-  const pkg = JSON.parse(pkgBuf.toString());
-  const repoString = pkg.repository?.url || pkg.repository;
-  const repoObject = gh(repoString);
-  assert(repoObject, "repo not found. Add repository string to your app's package.json file");
-  return `${repoObject.user}/${repoObject.repo}`;
-}
+  cancelUpdateTimer() {
+    clearInterval(this.updateTimer);
+    this.isActive = false;
+  }
 
-function validateInput(opts: IUpdateElectronAppOptions) {
-  const defaults = {
-    host: 'https://update.electronjs.org',
-    updateInterval: '10 minutes',
-    logger: console,
-    notifyUser: true,
-  };
-  const { host, updateInterval, logger, notifyUser } = Object.assign({}, defaults, opts);
+  guessRepo(electron: typeof Electron.Main) {
+    const pkgBuf = fs.readFileSync(path.join(electron.app.getAppPath(), 'package.json'));
+    const pkg = JSON.parse(pkgBuf.toString());
+    const repoString = pkg.repository?.url || pkg.repository;
+    const repoObject = gh(repoString);
+    assert(repoObject, "repo not found. Add repository string to your app's package.json file");
+    return `${repoObject.user}/${repoObject.repo}`;
+  }
 
-  // allows electron to be mocked in tests
-  const electron: typeof Electron.Main = (opts as any).electron || require('electron');
-
-  let updateSource = opts.updateSource;
-  // Handle migration from old properties + default to update service
-  if (!updateSource) {
-    updateSource = {
-      type: UpdateSourceType.ElectronPublicUpdateService,
-      repo: opts.repo || guessRepo(electron),
-      host,
+  validateInput(opts: IUpdateElectronAppOptions) {
+    const defaults = {
+      host: 'https://update.electronjs.org',
+      updateInterval: '10 minutes',
+      logger: console,
+      notifyUser: true,
     };
-  }
+    const { host, updateInterval, logger, notifyUser } = Object.assign({}, defaults, opts);
 
-  switch (updateSource.type) {
-    case UpdateSourceType.ElectronPublicUpdateService: {
-      assert(
-        updateSource.repo?.includes('/'),
-        'repo is required and should be in the format `owner/repo`',
-      );
+    // allows electron to be mocked in tests
+    const electron: typeof Electron.Main = (opts as any).electron || require('electron');
 
-      assert(
-        updateSource.host && isURL(updateSource.host) && updateSource.host.startsWith('https:'),
-        'host must be a valid HTTPS URL',
-      );
-      break;
+    let updateSource = opts.updateSource;
+    // Handle migration from old properties + default to update service
+    if (!updateSource) {
+      updateSource = {
+        type: UpdateSourceType.ElectronPublicUpdateService,
+        repo: opts.repo || this.guessRepo(electron),
+        host,
+      };
     }
-    case UpdateSourceType.StaticStorage: {
-      assert(
-        updateSource.baseUrl &&
-          isURL(updateSource.baseUrl) &&
-          updateSource.baseUrl.startsWith('https:'),
-        'baseUrl must be a valid HTTPS URL',
-      );
-      break;
+
+    switch (updateSource.type) {
+      case UpdateSourceType.ElectronPublicUpdateService: {
+        assert(
+          updateSource.repo?.includes('/'),
+          'repo is required and should be in the format `owner/repo`',
+        );
+
+        assert(
+          updateSource.host && isURL(updateSource.host) && updateSource.host.startsWith('https:'),
+          'host must be a valid HTTPS URL',
+        );
+        break;
+      }
+      case UpdateSourceType.StaticStorage: {
+        assert(
+          updateSource.baseUrl &&
+            isURL(updateSource.baseUrl) &&
+            updateSource.baseUrl.startsWith('https:'),
+          'baseUrl must be a valid HTTPS URL',
+        );
+        break;
+      }
     }
+
+    assert(
+      typeof updateInterval === 'string' && updateInterval.match(/^\d+/),
+      'updateInterval must be a human-friendly string interval like `20 minutes`',
+    );
+
+    assert(ms(updateInterval) >= 5 * 60 * 1000, 'updateInterval must be `5 minutes` or more');
+
+    assert(logger && typeof logger.log, 'function');
+
+    return { updateSource, updateInterval, logger, electron, notifyUser };
   }
-
-  assert(
-    typeof updateInterval === 'string' && updateInterval.match(/^\d+/),
-    'updateInterval must be a human-friendly string interval like `20 minutes`',
-  );
-
-  assert(ms(updateInterval) >= 5 * 60 * 1000, 'updateInterval must be `5 minutes` or more');
-
-  assert(logger && typeof logger.log, 'function');
-
-  return { updateSource, updateInterval, logger, electron, notifyUser };
 }
+
+const updateElectron = new updateElectronClass();
+const updateElectronApp = updateElectron.setup;
+
+export { updateElectron, updateElectronApp };

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,54 +1,54 @@
-import { expectType } from 'tsd'
-import { updateElectronApp, UpdateSourceType } from '../'
+import { expectType } from 'tsd';
+import { updateElectron, UpdateSourceType } from '../';
 
-expectType<void>(updateElectronApp())
+expectType<void>(updateElectron.setup());
 
 const customLogger = {
   log: (): void => {
-    return
+    return;
   },
   info: (): void => {
-    return
+    return;
   },
   error: (): void => {
-    return
+    return;
   },
   warn: (): void => {
-    return
-  }
-}
+    return;
+  },
+};
 
-updateElectronApp({
+updateElectron.setup({
   logger: customLogger,
-  host: "https://github.com",
+  host: 'https://github.com',
   notifyUser: true,
-  repo: "HashimotoYT/hab",
-  updateInterval: "10 minutes",
+  repo: 'HashimotoYT/hab',
+  updateInterval: '10 minutes',
 });
 
-updateElectronApp()
+updateElectron.setup();
 
-updateElectronApp({
+updateElectron.setup({
   logger: console,
-})
+});
 
-updateElectronApp({
+updateElectron.setup({
   updateSource: {
     type: UpdateSourceType.ElectronPublicUpdateService,
-  }
-})
+  },
+});
 
-updateElectronApp({
+updateElectron.setup({
   updateSource: {
     type: UpdateSourceType.ElectronPublicUpdateService,
     repo: 'a/b',
-    host: 'https://bar'
-  }
-})
+    host: 'https://bar',
+  },
+});
 
-updateElectronApp({
+updateElectron.setup({
   updateSource: {
     type: UpdateSourceType.StaticStorage,
     baseUrl: 'https://foo',
-  }
-})
+  },
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,85 +1,93 @@
-const { updateElectronApp: updater } = require('..')
-const repo = 'some-owner/some-repo'
-const os = require('os')
-const tmpdir = os.tmpdir()
-const fs = require('fs')
-const path = require('path')
+const { updateElectron: updater } = require('..');
+const repo = 'some-owner/some-repo';
+const os = require('os');
+const tmpdir = os.tmpdir();
+const fs = require('fs');
+const path = require('path');
 const electron = {
   app: {
-    getVersion: () => { return '1.2.3' },
+    getVersion: () => {
+      return '1.2.3';
+    },
     isReady: () => true,
-    on: (eventName) => { /* no-op */ },
-    getAppPath: () => { return tmpdir }
+    on: (eventName) => {
+      /* no-op */
+    },
+    getAppPath: () => {
+      return tmpdir;
+    },
   },
   autoUpdater: {
-    checkForUpdates: () => { /* no-op */ },
-    on: (eventName) => { /* no-op */ },
-    setFeedURL: () => { /* no-op */ }
+    checkForUpdates: () => {
+      /* no-op */
+    },
+    on: (eventName) => {
+      /* no-op */
+    },
+    setFeedURL: () => {
+      /* no-op */
+    },
   },
   dialog: {
-    showMessageBox: () => { /* no-op */ }
-  }
-}
+    showMessageBox: () => {
+      /* no-op */
+    },
+  },
+};
 
 beforeEach(() => {
-  jest.useFakeTimers()
-})
+  jest.useFakeTimers();
+});
 
 test('exports a function', () => {
-  expect(typeof updater).toBe('function')
-})
+  expect(typeof updater.setup).toBe('function');
+});
 
 describe('repository', () => {
-  fs.writeFileSync(
-    path.join(tmpdir, 'package.json'),
-    JSON.stringify({})
-  )
+  fs.writeFileSync(path.join(tmpdir, 'package.json'), JSON.stringify({}));
 
   test('is required', () => {
     expect(() => {
-      updater({ electron })
-    }).toThrowError('repo not found. Add repository string to your app\'s package.json file')
-  })
+      updater.setup({ electron });
+    }).toThrowError("repo not found. Add repository string to your app's package.json file");
+  });
 
   test('from opts', () => {
-    updater({ electron, repo: 'foo/bar' })
-  })
+    updater.setup({ electron, repo: 'foo/bar' });
+  });
 
   test('from package.json', () => {
-    fs.writeFileSync(
-      path.join(tmpdir, 'package.json'),
-      JSON.stringify({ repository: 'foo/bar' })
-    )
-    updater({ electron })
-  })
-})
+    fs.writeFileSync(path.join(tmpdir, 'package.json'), JSON.stringify({ repository: 'foo/bar' }));
+    updater.setup({ electron });
+  });
+});
 
 describe('host', () => {
   test('must a valid HTTPS URL', () => {
     expect(() => {
-      updater({ repo, electron, host: 'http://example.com' })
-    }).toThrowError('host must be a valid HTTPS URL')
-  })
-})
+      updater.setup({ repo, electron, host: 'http://example.com' });
+    }).toThrowError('host must be a valid HTTPS URL');
+  });
+});
 
 describe('logger', () => {
   test('must be an object defining a `log` function', () => {
     expect(() => {
-      updater({ repo, electron, logger: 'yep' })
-    }).toThrowError('logger.log is not a function')
-  })
-})
+      updater.setup({ repo, electron, logger: 'yep' });
+    }).toThrowError('logger.log is not a function');
+  });
+});
 
 describe('updateInterval', () => {
   test('must be 5 minutes or more', () => {
     expect(() => {
-      updater({ repo, electron, updateInterval: '20 seconds' })
-    }).toThrowError('updateInterval must be `5 minutes` or more')
-  })
+      updater.setup({ repo, electron, updateInterval: '20 seconds' });
+    }).toThrowError('updateInterval must be `5 minutes` or more');
+  });
 
   test('must be a string', () => {
     expect(() => {
-      updater({ repo, electron, updateInterval: 3000 })
-    }).toThrowError('updateInterval must be a human-friendly string interval like `20 minutes`')
-  })
-})
+      updater.setup({ repo, electron, updateInterval: 3000 });
+    }).toThrowError('updateInterval must be a human-friendly string interval like `20 minutes`');
+  });
+});


### PR DESCRIPTION
Hello, This PR wraps the current code in a class to make more room for customizations and more features:

-  Get the current status of the update process ( `updateElectron.isActive`, `updateElectron.isChecking`, `updateElectron.isError`, `updateElectron.isDownloading` and `updateElectron.isDownloaded` )
-  Adds a new function to allow the user to stop checking for updates ( `updateElectron.cancelUpdateTimer()` ) fixes https://github.com/electron/update-electron-app/issues/65 
-  Allow changing the dialoge messages (`updateElectron.dialogTitle`, `updateElectron.dialogDetail`, `updateElectron.dialogButtonRestart` and `updateElectron.dialogButtonLater`) fixes https://github.com/electron/update-electron-app/issues/116

// this is outdated. TODO: rewrite this PR to match https://github.com/justgo97/electron-inline-updater features