### PR TITLE
docs: code signing only required on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supports multiple update sources:
 Before using this module, make sure your Electron app meets these criteria:
 
 - Your app runs on macOS or Windows
-- Your builds are [code signed]
+- Your builds are [code signed] **(macOS only)**
 - **If** using `update.electronjs.org`
   - Your app has a public GitHub repository
   - Your builds are published to GitHub Releases


### PR DESCRIPTION
Closes #145

The original text was added when the module was first created in #15. I'm not sure if this was ever a technical requirement, but according to @MarshallOfSound, this is not true.

ref https://github.com/electron-forge/electron-forge-docs/issues/183#issuecomment-2192571984