### PR TITLE
refactor: remove `is-url` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,10 @@
   "license": "MIT",
   "dependencies": {
     "github-url-to-object": "^4.0.4",
-    "is-url": "^1.2.4",
     "ms": "^2.1.1"
   },
   "devDependencies": {
     "@types/github-url-to-object": "^4.0.1",
-    "@types/is-url": "^1.2.30",
     "@types/ms": "^0.7.31",
     "electron": "^22.0.0",
     "jest": "^29.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,8 +81,8 @@ const userAgent = format('%s/%s (%s: %s)', pkg.name, pkg.version, os.platform(),
 const supportedPlatforms = ['darwin', 'win32'];
 const isHttpsUrl = (maybeURL: string) => {
   try {
-    const url = new URL(maybeURL);
-    return url.protocol === 'https:';
+    const { protocol } = new URL(maybeURL);
+    return protocol === 'https:';
   } catch (e) {
     return false;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,11 +806,6 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#a3ff232bf7d5c55f38e4e45693eda2ebb545794d"
   integrity sha512-V46MYLFp08Wf2mmaBhvgjStM3tPa+2GAdy/iqoX+noX1//zje2x4XmrIU0cAwyClATsTmahbtoQ2EwP7I5WSiA==
 
-"@types/is-url@^1.2.30":
-  version "1.2.30"
-  resolved "https://registry.yarnpkg.com/@types/is-url/-/is-url-1.2.30.tgz#85567e8bee4fee69202bc3448f9fb34b0d56c50a"
-  integrity sha512-AnlNFwjzC8XLda5VjRl4ItSd8qp8pSNowvsut0WwQyBWHpOxjxRJm8iO6uETWqEyLdYdb9/1j+Qd9gQ4l5I4fw==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -2309,7 +2304,7 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
-is-url@^1.1.0, is-url@^1.2.4:
+is-url@^1.1.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
   integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==


### PR DESCRIPTION
Removes an unnecessary package and cleans up the helper that we were using to check for HTTPS URLs.