### PR TITLE
fix: host must be a valid HTTPS URL when using ElectronPublicUpdateService

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -323,6 +323,10 @@ function validateInput(opts: IUpdateElectronAppOptions) {
         'repo is required and should be in the format `owner/repo`',
       );
 
+      if (!updateSource.host) {
+        updateSource.host = host;
+      }
+
       assert(updateSource.host && isHttpsUrl(updateSource.host), 'host must be a valid HTTPS URL');
       break;
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,7 +4,13 @@ import path from 'node:path';
 
 import { autoUpdater, dialog } from 'electron';
 
-import { updateElectronApp, makeUserNotifier, IUpdateInfo, IUpdateDialogStrings } from '../src';
+import {
+  updateElectronApp,
+  makeUserNotifier,
+  IUpdateInfo,
+  IUpdateDialogStrings,
+  UpdateSourceType,
+} from '../src';
 const repo = 'some-owner/some-repo';
 
 beforeEach(() => {
@@ -48,6 +54,15 @@ describe('updateElectronApp', () => {
       expect(() => {
         updateElectronApp({ repo, host: 'http://example.com' });
       }).toThrow('host must be a valid HTTPS URL');
+    });
+
+    it('from default', () => {
+      updateElectronApp({
+        updateSource: {
+          type: UpdateSourceType.ElectronPublicUpdateService,
+          repo,
+        },
+      });
     });
   });
 


### PR DESCRIPTION
Fix the issue [#155](https://github.com/electron/update-electron-app/issues/155)

When using `ElectronPublicUpdateService`, if no default `host` is provided, a default value should be assigned, and tests should be included.