### PR TITLE
feat: support not to auto check update & manual check update

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Once you've called `updateElectronApp` as documented above, that's it! Here's wh
 Additional Options:
 
 - `updateInterval` String (optional) - How frequently to check for updates. Defaults to `10 minutes`. Minimum allowed interval is `5 minutes`. This is a human readable interval supported by the [`ms`](https://github.com/vercel/ms#readme) module
+- `autoCheck` Boolean (optional) - Decides whether to automatically check for updates. Defaults to `true`.
 - `logger` Object (optional) - A custom logger object that defines a `log` function. Defaults to `console`. See [electron-log](https://github.com/megahertz/electron-log), a module that aggregates logs from main and renderer processes into a single file.
 - `notifyUser` Boolean (optional) - Defaults to `true`.  When enabled the user will be
   prompted to apply the update immediately after download.

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,11 @@ export interface IUpdateElectronAppOptions<L = ILogger> {
    */
   readonly updateInterval?: string;
   /**
+   * @param {Boolean} autoCheck Decides whether to automatically check for updates
+   *                            Defaults to `true`.
+   */
+  readonly autoCheck?: boolean;
+  /**
    * @param {Object} logger A custom logger object that defines a `log` function.
    *                        Defaults to `console`. See electron-log, a module
    *                        that aggregates logs from main and renderer processes into a single file.
@@ -152,7 +157,7 @@ export function updateElectronApp(opts: IUpdateElectronAppOptions = {}) {
 }
 
 function initUpdater(opts: ReturnType<typeof validateInput>) {
-  const { updateSource, updateInterval, logger } = opts;
+  const { updateSource, updateInterval, autoCheck, logger } = opts;
 
   // exit early on unsupported platforms, e.g. `linux`
   if (!supportedPlatforms.includes(process?.platform)) {
@@ -241,11 +246,27 @@ function initUpdater(opts: ReturnType<typeof validateInput>) {
     );
   }
 
-  // check for updates right away and keep checking later
-  autoUpdater.checkForUpdates();
-  setInterval(() => {
+  if (autoCheck) {
+    // check for updates right away and keep checking later
     autoUpdater.checkForUpdates();
-  }, ms(updateInterval));
+    setInterval(() => {
+      autoUpdater.checkForUpdates();
+    }, ms(updateInterval));
+  }
+}
+
+export function checkForUpdates() {
+  return new Promise((resolve) => {
+    autoUpdater.checkForUpdates();
+
+    autoUpdater.once('update-available', () => {
+      resolve(true);
+    });
+
+    autoUpdater.once('update-not-available', () => {
+      resolve(false);
+    });
+  });
 }
 
 /**
@@ -296,11 +317,12 @@ function validateInput(opts: IUpdateElectronAppOptions) {
   const defaults = {
     host: 'https://update.electronjs.org',
     updateInterval: '10 minutes',
+    autoCheck: true,
     logger: console,
     notifyUser: true,
   };
 
-  const { host, updateInterval, logger, notifyUser, onNotifyUser } = Object.assign(
+  const { host, updateInterval, autoCheck, logger, notifyUser, onNotifyUser } = Object.assign(
     {},
     defaults,
     opts,
@@ -348,5 +370,5 @@ function validateInput(opts: IUpdateElectronAppOptions) {
 
   assert(logger && typeof logger.log, 'function');
 
-  return { updateSource, updateInterval, logger, notifyUser, onNotifyUser };
+  return { updateSource, updateInterval, autoCheck, logger, notifyUser, onNotifyUser };
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -132,3 +132,29 @@ describe('makeUserNotifier', () => {
     );
   });
 });
+
+describe('autoCheck', () => {
+  it('make sure checkForUpdates is called', () => {
+    const checkForUpdatesSpy = jest
+      .spyOn(autoUpdater, 'checkForUpdates')
+      .mockImplementation(() => Promise.resolve());
+
+    updateElectronApp({ repo: 'foo/bar' });
+
+    expect(checkForUpdatesSpy).toHaveBeenCalled();
+
+    checkForUpdatesSpy.mockRestore();
+  });
+
+  it('make sure checkForUpdates is not called', () => {
+    const checkForUpdatesSpy = jest
+      .spyOn(autoUpdater, 'checkForUpdates')
+      .mockImplementation(() => Promise.resolve());
+
+    updateElectronApp({ repo: 'foo/bar', autoCheck: false });
+
+    expect(checkForUpdatesSpy).not.toHaveBeenCalled();
+
+    checkForUpdatesSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Implemented the issue #164

- `autoCheck` - which defaults to `true`. It can be set to false to disable automatic update checks.
- `checkForUpdates()` - manually check for updates.

However, I did not implement the final `installUpdate` function
Because the correct installation process should be executed after the file has been downloaded

```js
autoUpdater.once('update-downloaded', () => {
  autoUpdater.quitAndInstall();
});
```
