### PR TITLE
build: use yarn lint-staged in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+yarn lint-staged


### PR DESCRIPTION
lint-staged is already a devDependency — `yarn lint-staged` fails closed if the local bin is missing (fresh clone before `yarn install`, etc.) instead of `npx` falling through to a registry fetch.