### PR TITLE
build: only include necessary files in final package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
     "ts-jest": "^29.2.5",
     "typescript": "^6.0.2"
   },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
     "lint": "oxlint && oxfmt --check .",


### PR DESCRIPTION
Things like `.yarn` and `.github` don't need to be in the final package distributed to users.

Uncompressed package size goes from 3.1mb to 40kb (77x smaller!)